### PR TITLE
Prefix Apple to both distributable labels

### DIFF
--- a/components/sections/footer/links.js
+++ b/components/sections/footer/links.js
@@ -10,7 +10,7 @@ const Links = () => (
     </li>
     <li>
       <a target="_blank" rel="noopener" onClick={() => ReactGA.pageview('/download/x64')} href="/api/download/x64" download>
-        Download for Intel
+        Download for Apple (Intel)
       </a>
     </li>
     <li>

--- a/components/sections/hero/index.js
+++ b/components/sections/hero/index.js
@@ -36,7 +36,7 @@ const Hero = () => (
                 href="/api/download/x64"
                 download
               >
-                Download for Intel
+                Download for Apple (Intel)
               </a>
             </li>
           </ul>


### PR DESCRIPTION
Update the labels of distributables to make it more clear to users which one they should download.

Previously:
- Apple (M1) 
- Intel

![image (12)](https://user-images.githubusercontent.com/3030010/157559976-4ffa6f81-91a5-42af-90b1-07cc999c4acc.png)

Proposed:
- Apple (M1)
- Apple (Intel)

<img width="325" alt="image" src="https://user-images.githubusercontent.com/3030010/157560580-7e65aaef-49af-4317-aba8-fe234dd83306.png">

Why?

The distinction between the two may not be obvious to the average user. And since Apple (M1) is the first in the list and includes "Apple" people are inclined to use that rather than the Intel one.

When a user selects the wrong one, apple doesn't do a great job of telling users why. And it may be assumed that Kap is broken somehow. This change at least makes the user consider their options before blindly selecting the first item in the list.

![image (11)](https://user-images.githubusercontent.com/3030010/157559857-7d79d832-0c6a-43bf-b485-02a3439df2ff.png)


